### PR TITLE
Fixed evil assert(ref == 0)

### DIFF
--- a/libjack/jack/midiport.d
+++ b/libjack/jack/midiport.d
@@ -81,7 +81,12 @@ public:
   JackMidiEvent front() {
     JackMidiEvent ev;
     int ret = jack_midi_event_get(&ev, ptr_, index_);
-    assert(ret == 0);
+    if (ret != 0) {
+        /* ENODATA -- jack api does not guarantee that it won't ENODATA even if index_ < get_event_count.
+           Setting size to 0 should prevent a sane programmer from accessing ev.buffer.
+         */
+        ev.size = 0;
+    }
     return ev;
   }
 


### PR DESCRIPTION
```
in JackMidiPortBufferRange.front().
```

Unfortunately, this assert triggers in the jack callback, so the program
crashes with exit code -11 instead of giving the usual assert-failed
output. There might be a better choice than setting ev.size to zero
though.
